### PR TITLE
Bug fix for bfactor

### DIFF
--- a/bfactor
+++ b/bfactor
@@ -204,7 +204,7 @@ if {$nf < $window} {
 	set cnt_realtime [expr $cnt_realtime + $window]
 	bfactor "protein" 0 [expr $window-1] $str_outfile $cnt_realtime
 	animate delete all
-	set interval_start [expr $interval_start + $window]
+	set interval_start [expr $interval_end + 1]
 # In case the transition is perfectly lined up to the end of the file
 } elseif {$nf == window} {
 	set interval_start 0
@@ -231,7 +231,7 @@ if {$nf < $window} {
 	set cnt_realtime [expr $cnt_realtime + $window]
 	bfactor "protein" 0 [expr $window-1] $str_outfile $cnt_realtime
 	animate delete all
-	set interval_start [expr $interval_start + $window]
+	set interval_start [expr $interval_end + 1]
 # In case the transition is perfectly lined up to the end of the file
 } elseif {$nf == window} {
 	set interval_start 0


### PR DESCRIPTION
Fixed bug that did not correctly transition between dcd files: from "set interval_start [expr $interval_start + $window]" to "set interval_start [expr $interval_end + 1]" in lines 207 and 234. Due to the bug, some frames between dcd files (between 0 and df-1) were not analyzed.
